### PR TITLE
Update decoder repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A simple tool to extract the plain text values of [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets). This action was made to show the importance of limiting who can run workflows in repositories with secrets. 
 
-This action takes a string, `secret` as input and prints an encoded version of it to the console. You can then use [this tool](https://plabick.github.io/ActionsSecretDecoder/) to get the secret in plain text. 
+This action takes a string, `secret` as input and prints an encoded version of it to the console. You can then use [this tool](https://plabick.github.io/Actions-Secret-Decoder/) to get the secret in plain text. 
 ### Usage
 ```yaml
     - name: Extract A Juicy Secret
@@ -17,7 +17,7 @@ This action takes a string, `secret` as input and prints an encoded version of i
 * Encoded Secret: epousfbenztfdsfut *
 *************************************
 To view the plain-text secret, use the decoder
-plabick.github.io/ActionsSecretDecoder/
+plabick.github.io/Actions-Secret-Decoder/
 ```
 ## Why is the output encoded?
 GitHub redacts text that matches secrets from the console. The only way to output secrets in the console is to encode them. 

--- a/src/action.ts
+++ b/src/action.ts
@@ -7,7 +7,7 @@ import { encode } from "./encode";
 export function run(secret: string): [string, string] {
   const LINE_DASH = "*";
   const decoder_link_message =
-    "To view the plain-text secret, use the decoder\nplabick.github.io/ActionsSecretDecoder/";
+    "To view the plain-text secret, use the decoder\nplabick.github.io/Actions-Secret-Decoder/";
   const encoded_secret = encode(secret);
   const encoded_secret_message = `${LINE_DASH} Encoded Secret: ${encoded_secret} ${LINE_DASH}`;
   const divider = LINE_DASH.repeat(encoded_secret_message.length);

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -2,7 +2,7 @@ import { encode } from "punycode";
 import { run } from "../src/action";
 
 const SIMPLE_TEST_STRING = "abcdefg"
-const FULL_MESSAGE = "***************************\n* Encoded Secret: bcdefgh *\n***************************\nTo view the plain-text secret, use the decoder\nplabick.github.io/ActionsSecretDecoder/"
+const FULL_MESSAGE = "***************************\n* Encoded Secret: bcdefgh *\n***************************\nTo view the plain-text secret, use the decoder\nplabick.github.io/Actions-Secret-Decoder/"
 
 describe("test run function", () => {
   it("Should produce correctly formatted output message in out[1]", () => {


### PR DESCRIPTION
The decoder repo name was changed to add dashes between words. This change broke links to that repo. 